### PR TITLE
Prompt engineering, change from openapi to gemini and task creation

### DIFF
--- a/ai_assistant.py
+++ b/ai_assistant.py
@@ -1,6 +1,7 @@
 import os
+import json
 from datetime import datetime
-from openai import OpenAI
+from google import genai
 from habitica_api import format_tasks
 
 def generate_chatgpt_suggestion(tasks, user_context):
@@ -10,34 +11,122 @@ def generate_chatgpt_suggestion(tasks, user_context):
     tasks_text = format_tasks(tasks)
     today_date = datetime.now().strftime("%d/%m/%Y")
     
-    system_context = (
-        "You are Klaus, a calm, polite, and objective personal assistant. "
-        "Your mission is to analyze the user's tasks and provide practical suggestions. "
-        "Always use a respectful, yet concise tone.\n\n"
-        "=== Telegram Formatting Instructions ===\n"
-        "- Use plain text. You may use line breaks to separate topics.\n"
-        "- Avoid Markdown formatting.\n"
-        "- Use emojis to indicate priority and status.\n\n"
-        f"Today is {today_date}. Below are the user's tasks, separated by semicolons:\n"
+    ai_prompt_system_context = (
+        "Você é Klaus, um assistente pessoal calmo, educado e objetivo. "
+        "Sua missão é analisar as tarefas do usuário e fornecer sugestões práticas. "
+        "Use sempre um tom respeitoso, porém conciso.\n\n"
+        "=== Instruções de Formatação para Telegram ===\n"
+        "- Use texto simples. Você pode usar quebras de linha para separar tópicos.\n"
+        "- Evite formatação em Markdown.\n"
+        "- Use emojis para indicar prioridade e status.\n\n"
+        f"Hoje é {today_date}. Abaixo estão as tarefas do usuário, separadas por ponto e vírgula:\n"
         f"{tasks_text}\n\n"
-        "=== Example Response ===\n"
-        "Good morning! You have some pending tasks today. "
-        "I suggest starting with the tasks that have the closest or overdue due dates. "
-        "Then, if you have time, move on to the others. "
-        "Avoid letting tasks accumulate for several days.\n\n"
-        "Please prioritize urgent or high-impact tasks, and maintain a positive tone. "
-        "Respond considering the user's context and the listed tasks."
+        "=== Exemplo de Resposta ===\n"
+        "Bom dia! Você tem algumas tarefas pendentes hoje. "
+        "Sugiro começar pelas tarefas com datas mais próximas ou já vencidas. "
+        "Em seguida, se tiver tempo, avance para as demais. "
+        "Evite deixar tarefas se acumularem por vários dias.\n\n"
+        "Por favor, priorize tarefas urgentes ou de maior impacto e mantenha um tom positivo. "
+        "Responda considerando o contexto do usuário e as tarefas listadas."
     )
 
-    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
 
-    response = client.responses.create(
-        model="gpt-4.1",
-        input=[
-            {"role": "system", "content": system_context},
-            {"role": "user",   "content": user_context}
-        ],
-        temperature=0.5
+    response = client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=user_context,
+        config=genai.types.GenerateContentConfig(
+            system_instruction=ai_prompt_system_context,
+            temperature=0.5
+        )
     )
 
-    return response.output_text
+    return response.text
+
+def interpret_user_message(user_message):
+    """
+    Interprets the user message to determine whether it refers to a new task creation,
+    a request for task status, or is unrelated. It returns a structured JSON with
+    the following fields:
+    {
+      "message": [original user message],
+      "type": ["new_task" | "task_status" | "unrelated"],
+      "task": [brief task title or null],
+      "date": [date mentioned like "hoje", "amanhã", or null],
+      "priority": ["low" | "medium" | "high" | null]
+    }
+    """
+    
+    ai_prompt_engineering_prompt = (
+        """Aja como um especialista em interpretação de linguagem natural e extração de informações a partir de mensagens de texto. Sua tarefa é classificar a intenção da mensagem do usuário e extrair informações relevantes.
+        INSTRUÇÃO
+
+        Você receberá uma mensagem de usuário. Sua tarefa é determinar se a mensagem:
+
+        - Refere-se à criação de uma nova tarefa.
+        - Solicita o status de tarefas existentes.
+        - Não está relacionada a nenhuma das anteriores.
+
+        Você DEVE extrair os seguintes campos e retorná-los em JSON no seguinte formato:
+
+        {
+        "message": [mensagem original do usuário],
+        "type": ["new_task" | "task_status" | "unrelated"],
+        "task": [título resumido da tarefa ou null],
+        "date": [data mencionada como "hoje", "amanhã" ou null],
+        "priority": ["low" | "medium" | "high" | null]
+        }
+
+        É imprescindível que esse retorno não tenha nenhuma formatação, nem mesmo algo como ```json.
+
+        Seja rigoroso em sua classificação. Se uma mensagem for ambígua ou não se referir claramente a uma tarefa ou ao seu status, classifique-a como "unrelated".
+
+        Ao extrair a prioridade, considere não apenas palavras‑chave explícitas, mas também a urgência implícita no tom. Por exemplo:
+
+        - "preciso muito", "urgente", "o quanto antes" → high  
+        - "se possível", "talvez", "mais tarde" → low
+
+        Mantenha o texto original em português nos campos "message" e "date".
+
+        EXEMPLOS
+
+        Usuário: "Preciso ir na academia hoje"  
+        Saída: { "message": "Preciso ir na academia hoje", "type": "new_task", "task": "ir na academia", "date": "hoje", "priority": null }
+
+        Usuário: "Quais tarefas minhas estão atrasadas?"  
+        Saída: { "message": "Quais tarefas minhas estão atrasadas?", "type": "task_status", "task": null, "date": null, "priority": null }
+
+        Usuário: "Tenho tarefas para hoje? Quais?"  
+        Saída: { "message": "Tenho tarefas para hoje? Quais?", "type": "task_status", "task": null, "date": "hoje", "priority": null }
+
+        Usuário: "A pizza chegou"  
+        Saída: { "message": "A pizza chegou", "type": "unrelated", "task": null, "date": null, "priority": null }
+
+        FIM
+
+        Agora, processe a seguinte mensagem de acordo com as instruções."""
+    )
+
+    client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+
+    response = client.models.generate_content(
+        model="gemini-2.0-flash-lite",
+        contents=user_message,
+        config=genai.types.GenerateContentConfig(
+            system_instruction=ai_prompt_engineering_prompt,
+            temperature=0.0
+        )
+    )
+
+    result_text = response.text
+    try:
+        result = json.loads(result_text)
+    except json.JSONDecodeError:
+        result = {
+            "message": user_message,
+            "type": "unrelated",
+            "task": None,
+            "date": None,
+            "priority": None
+        }
+    return result

--- a/habitica_api.py
+++ b/habitica_api.py
@@ -69,3 +69,20 @@ def format_tasks(tasks):
     # Combine both lists with semicolon separators
     tasks_text = ";".join(todos_text) + ";" + ";".join(dailies_text)
     return tasks_text
+
+def create_task_todo(text, notes="", priority=1, iso_date=None):
+    url = "https://habitica.com/api/v3/tasks/user"
+    payload = {
+        "type": "todo",
+        "text": text,
+        "notes": notes,
+        "priority": priority
+    }
+    if iso_date:
+        payload["date"] = iso_date  # Ex: "2025-04-20T12:00:00.000Z"
+
+    response = requests.post(url, headers=HEADERS, json=payload)
+    if response.status_code != 201:
+        raise Exception(f"Error creating task: {response.text}")
+
+    return response.json()["data"]

--- a/main.py
+++ b/main.py
@@ -1,27 +1,79 @@
 import functions_framework
-from habitica_api import get_tasks
-from ai_assistant import generate_chatgpt_suggestion
-from handlers.telegram_handler import handle_telegram_request
+from datetime import datetime, timedelta
+from habitica_api import get_tasks, create_task_todo
+from ai_assistant import generate_chatgpt_suggestion, interpret_user_message
+from handlers.telegram_handler import validate_telegram_request, send_telegram_message
 
 @functions_framework.http
 def webhook(request):
     """
-    Entry point for HTTP requests. Dispatches requests based on the source.
-    Defaults to the Telegram handler if the source is not specified.
+    Entry point for HTTP requests.
+    First, validates the request if it comes from Telegram.
+    Then, interprets the user message and, based on its type:
+      - For "task_status": fetch tasks and generate a GPT suggestion.
+      - For "new_task": creates a new task using Habitica's API.
+      - Otherwise: returns a message indicating that the message is unrelated.
+    For Telegram requests, the response is also sent via Telegram.
     """
+
     source = request.args.get("source", "telegram").lower()
     
+    telegram_chat_id = None
     if source == "telegram":
-        return handle_telegram_request(request)
-    else:
-        try:
-            body = request.get_json(silent=True)
-            if not body:
-                return "No body", 400
+        validation = validate_telegram_request(request)
+        if not validation.get("valid"):
+            return validation.get("message"), validation.get("status_code")
+        telegram_chat_id = validation.get("chat_id")
+    
+    try:
+        body = request.get_json(silent=True)
+        if not body:
+            return "No body", 400
 
-            user_context = body.get("text", "What are my tasks?")
+        user_message = body.get("message", "")
+        user_message = user_message.get("text", "What are my tasks?")
+
+        # First, interpret the user message (for any source)
+        interpretation = interpret_user_message(user_message)
+        message_type = interpretation.get("type")
+
+        response_message = ""
+        
+        if message_type == "task_status":
             tasks = get_tasks()
-            response = generate_chatgpt_suggestion(tasks, user_context)
-            return response, 200
-        except Exception as e:
-            return f"Error: {str(e)}", 500
+            response_message = generate_chatgpt_suggestion(tasks, user_message)
+        elif message_type == "new_task":
+            # For task creation, extract the task title, priority and date from the interpretation
+            task_title = interpretation.get("task") or user_message
+            
+            # Map priority string to numeric value.
+            priority_text = interpretation.get("priority")
+            priority_mapping = {"low": 0.1, "medium": 1, "high": 2}
+            priority_value = priority_mapping.get(priority_text, 1)
+            
+            # Convert date from natural language to ISO format if possible.
+            date_text = interpretation.get("date")
+            iso_date = None
+            if date_text:
+                dt_now = datetime.now()
+                if date_text.lower() == "hoje":
+                    iso_date = dt_now.isoformat() + "Z"
+                elif date_text.lower() == "amanhã":
+                    iso_date = (dt_now + timedelta(days=1)).isoformat() + "Z"
+            
+            # Create the new task using Habitica API.
+            created_task = create_task_todo(task_title, notes="", priority=priority_value, iso_date=iso_date)
+            response_message = "Tarefa criada! Vamos em frente!"
+        else:
+            response_message = "The message is unrelated to task management.'"
+
+        # If source is telegram, send the message via Telegram.
+        if source == "telegram" and telegram_chat_id:
+            send_telegram_message(telegram_chat_id, response_message)
+            return "Message sent via Telegram.", 200
+
+        # For non-Telegram sources, return the response in the HTTP body.
+        return response_message, 200
+
+    except Exception as e:
+        return f"Error: {str(e)}", 500

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ You can test the endpoint using a tool like curl. For instance, to simulate a ge
 ```bash
 curl -X POST "http://localhost:8080?source=web" \
     -H "Content-Type: application/json" \
-    -d '{"text": "What are my tasks?"}'
+    -d '{"message":{"text": "What are my tasks?"}}'
 ```
 
 5. **Telegram Integration Testing:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai
+google-genai
 requests
 functions-framework
 python-telegram-bot


### PR DESCRIPTION
## Prompt Engineering, Gemini AI Integration & Task Creation Support

**This pull request includes the following key updates:**

1. **Switched from OpenAI to Google Gemini**  
   - Removed the `openai` client and added `google-genai` (`Vertex AI`) in `ai_assistant.py`.  
   - Translated prompt contexts (`ai_prompt_system_context`, `ai_prompt_engineering_prompt`) into Portuguese.  
   - Updated model invocations to use `chat-bison@001` and `gemini-2.0-flash`/`gemini-2.0-flash-lite`.

2. **Added `interpret_user_message` Function**  
   - New function classifies incoming text as `new_task`, `task_status`, or `unrelated`.  
   - Extracts `message`, `type`, `task`, `date`, and `priority` fields, returning structured JSON.  
   - Includes JSON parse fallback to `unrelated` on failures.

3. **Habitica “todo” Task Creation**  
   - Introduced `create_task_todo` in `habitica_api.py`.  
   - Main handler now handles `"new_task"` type:  
     - Maps textual priority (`low`/`medium`/`high`) to numeric values.  
     - Converts “hoje” and “amanhã” to ISO 8601 dates.  
     - Calls Habitica API to create the task.

4. **Secure Allowed Chat IDs**  
   - In `handlers/telegram_handler.py`, require the `TELEGRAM_ALLOWED_CHAT_IDS` environment variable (no default).  
   - Fail fast on startup if the variable is missing, preventing unintended exposure.

5. **Refactored Main Flow**  
   - Unified message processing: always interpret first, then branch on `type`.  
   - For `task_status`, fetch tasks and generate suggestions.  
   - For `new_task`, create tasks as above.  
   - For `unrelated`, return an informative placeholder.  
   - When `source=telegram`, send responses via Telegram bot; otherwise return HTTP body.

6. **Documentation & Examples**  
   - Updated `README.md` curl examples to the new `{"message":{"text":"…"}}` format.  
   - Updated `requirements.txt` to use `google-genai`.