### PR TITLE
Restructure modules, remove legacy memory store & unify imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ eggs/
 lib/
 lib64/
 parts/
+my-venv/
 sdist/
 var/
 wheels/

--- a/ai_assistant.py
+++ b/ai_assistant.py
@@ -2,9 +2,10 @@ import os
 import json
 from datetime import datetime
 from google import genai
-from habitica_api import format_tasks
+from externals.habitica_api import format_tasks
+from typing import List, Dict, Any
 
-def chat(message):
+def chat(message: str, context: str) -> str:
     """
     Generates a message using the Gemini API based on the provided user message.
     """
@@ -20,6 +21,8 @@ def chat(message):
         "- Use emojis para indicar prioridade e status.\n\n"
         f"Hoje é {today_date}.\n"
         "Na mensagem a seguir, o usuário quer apenas conversar.\n"
+        "O contexto de suas conversas anteriores é o seguinte:\n"
+        f"{context}\n\n"
         "Sinta-se à vontade para responder como quiser, fazer perguntas ou dar sugestões.\n"
         "Abaixo está a mensagem do usuário:\n"
     )
@@ -37,7 +40,8 @@ def chat(message):
 
     return response.text
 
-def generate_chatgpt_suggestion(tasks, user_context):
+
+def generate_tasks_suggestion(tasks: List[Dict[str, Any]], user_context: str) -> str:
     """
     Generates a suggestion using ChatGPT based on the provided tasks and user context.
     """
@@ -76,7 +80,8 @@ def generate_chatgpt_suggestion(tasks, user_context):
 
     return response.text
 
-def interpret_user_message(user_message):
+
+def interpret_user_message(user_message: str) -> Dict[str, Any]:
     """
     Interprets the user message to determine whether it refers to a new task creation,
     a request for task status, or is unrelated. It returns a structured JSON with
@@ -115,7 +120,7 @@ def interpret_user_message(user_message):
 
         Seja rigoroso em sua classificação. Se uma mensagem for ambígua ou não se referir claramente a uma tarefa ou ao seu status, classifique-a como "unrelated".
 
-        Ao extrair a prioridade, considere não apenas palavras‑chave explícitas, mas também a urgência implícita no tom. Por exemplo:
+        Ao extrair a prioridade, considere não apenas palavras-chave explícitas, mas também a urgência implícita no tom. Por exemplo:
 
         - "preciso muito", "urgente", "o quanto antes" → high  
         - "se possível", "talvez", "mais tarde" → low

--- a/data/memory.py
+++ b/data/memory.py
@@ -1,0 +1,25 @@
+import os
+import uuid
+from datetime import datetime
+from google.cloud import firestore
+from typing import Tuple, Dict, Any, List, Optional
+
+
+firestore_client = firestore.Client(project=os.getenv("DB_PROJECT_ID"), database=os.getenv("DB_NAME"))
+
+
+def save_message(role: str, text: str) -> Tuple[str, Dict[str, Any]]:
+    data = {
+        "role": role,
+        "text": text,
+        "timestamp": datetime.utcnow().isoformat()
+    }
+    doc_ref = firestore_client.collection("messages").add(data)
+    return doc_ref[1].id, data
+
+
+def get_latest_messages(limit: int = 5) -> List[Dict[str, Any]]:
+    messages_ref = firestore_client.collection("messages")
+    query = messages_ref.order_by("timestamp", direction=firestore.Query.DESCENDING).limit(limit)
+    results = query.stream()
+    return [doc.to_dict() for doc in results]

--- a/handlers/telegram_handler.py
+++ b/handlers/telegram_handler.py
@@ -1,7 +1,8 @@
 import os
 import requests
-from habitica_api import get_tasks
-from ai_assistant import generate_chatgpt_suggestion
+from typing import Any, Dict
+from externals.habitica_api import get_tasks
+from ai_assistant import generate_tasks_suggestion
 
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 TELEGRAM_SECRET_TOKEN = os.getenv("TELEGRAM_SECRET_TOKEN")
@@ -15,10 +16,11 @@ ALLOWED_CHAT_IDS = {
     for chat_id in allowed_ids_str.split(",") if chat_id.strip()
 }
 
-def validate_telegram_request(request):
+
+def validate_telegram_request(request: Any) -> Dict[str, Any]:
     """
     Validates the Telegram request.
-    
+
     Returns a dictionary containing:
       - valid: (bool) whether the request is valid.
       - status_code: (int) appropriate HTTP status code.
@@ -33,11 +35,11 @@ def validate_telegram_request(request):
     body = request.get_json(silent=True)
     if not body or "message" not in body:
         return {"valid": False, "status_code": 400, "message": "Bad Request: Missing message data."}
-    
+
     message = body.get("message")
     if not message:
         return {"valid": False, "status_code": 400, "message": "Bad Request: Message not provided."}
-    
+
     chat = message.get("chat")
     if not chat or not chat.get("id"):
         return {"valid": False, "status_code": 400, "message": "Bad Request: Invalid chat data."}
@@ -50,7 +52,8 @@ def validate_telegram_request(request):
     text = message.get("text", "What are my tasks?")
     return {"valid": True, "status_code": 200, "chat_id": chat_id, "text": text}
 
-def send_telegram_message(chat_id, text):
+
+def send_telegram_message(chat_id: int, text: str) -> None:
     """
     Sends a message to the specified Telegram chat.
     """

--- a/readme.md
+++ b/readme.md
@@ -1,23 +1,19 @@
-# Habitica Task Assistant
+# Klaus Task Assistant
 
-This project integrates with Habitica to fetch and process user tasks, then uses OpenAI's GPT-4.1 (or similar model) to generate suggestions based on the tasks. The project supports a Telegram-based front-end through which users can interact with the assistant, but it is designed in a modular fashion to allow additional front-ends.
+Klaus is a cloud-native, modular Telegram bot that integrates with Habitica’s API and Google’s Gemini (Vertex AI) to manage “todo” and “daily” tasks through natural-language commands. It interprets user messages to check status, create new tasks, or mark tasks as complete—using fuzzy matching to handle approximate titles—and generates AI-driven suggestions and free-form chat responses.
 
 ## Project Structure
 
+```
 .
 ├── main.py                      # Entry point for Cloud Functions (HTTP request dispatcher)
-
 ├── habitica_api.py              # Module to interact with Habitica API and format tasks
-
 ├── ai_assistant.py              # Module to generate suggestions via ChatGPT
-
 ├── handlers
-
 │   └── telegram_handler.py      # Telegram-specific request handler
-
 ├── requirements.txt             # Python package dependencies
-
 └── README.md                    # Project documentation and best practices
+```
 
 ## Environment Variables
 
@@ -29,7 +25,8 @@ For the correct functioning of the project, make sure to set the following envir
 - **TELEGRAM_BOT_TOKEN**: The token for your Telegram bot.
 - **TELEGRAM_SECRET_TOKEN**: A secret token used to validate incoming Telegram requests.
 - **TELEGRAM_ALLOWED_CHAT_IDS**: List of allowed chat IDS that can use this bot on telegram
-
+- **DB_PROJECT_ID**: Name of the project in GCP
+- **DB_NAME**: Name of the database
 ## Best Practices
 
 - **Separation of Concerns**:  
@@ -70,6 +67,9 @@ export HABITICA_API_TOKEN="your_habitica_api_token"
 export GEMINI_API_KEY="your_gemini_api_key"
 export TELEGRAM_BOT_TOKEN="your_telegram_bot_token"
 export TELEGRAM_SECRET_TOKEN="your_telegram_secret_token"
+export TELEGRAM_ALLOWED_CHAT_IDS="your_allowed_telegram_chats"
+export DB_PROJECT_ID="your_gcp_project_id"
+export DB_NAME="your_database_name_on_gcp"
 ```
 
 Alternatively, you can use a .env file with a tool like python-dotenv.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 functions-framework
 python-telegram-bot
 rapidfuzz
+google-cloud-firestore


### PR DESCRIPTION
This PR enhances our conversational memory feature, restructures the Habitica client into an `externals/` folder, and updates all imports/type signatures accordingly. Key changes include:

1. **Memory persistence**  
   - **Added** `data/memory.py` to save user/assistant messages in Firestore (`save_message`, `get_latest_messages`)  
   - Integrated memory calls in `main.py` so that free-form chat falls back on recent context  

2. **Habitica API relocation**  
   - **Moved** `habitica_api.py` → `externals/habitica_api.py`  
   - **Added** full type hints (`List[Dict]`, thresholds, return types) and docstrings for `find_task_by_message`, `get_tasks`, `format_tasks`, `create_task_todo`, `complete_task`  

3. **AI assistant updates**  
   - In `ai_assistant.py`, **restored** `chat(message: str, context: str)` signature to accept conversation history  
   - **Renamed** suggestion function back to `generate_tasks_suggestion(...)` with precise type annotations  
   - **Annotated** `interpret_user_message(user_message: str) -> Dict[str, Any]`  

4. **Telegram handler adjustments**  
   - **Switched** to import from `externals.habitica_api` and `generate_tasks_suggestion`  
   - **Added** type hints to `validate_telegram_request` and `send_telegram_message` signatures  

5. **Main flow & helpers**  
   - **Introduced** `_parse_iso_date`, `_handle_task_status`, `_handle_new_task`, `_handle_task_conclusion` in `main.py`  
   - **Persisted** user/assistant messages around each request  
   - **Dispatched** based on intent, with memory-backed fallback for “unrelated” chat  

6. **Miscellaneous cleanup**  
   - **.gitignore**: added `my-venv/`  
   - **requirements.txt**: added `google-cloud-firestore`  
   - **README.md**: updated name to “Klaus Task Assistant” and added `DB_PROJECT_ID` / `DB_NAME` env vars  

Please verify that Firestore credentials (`DB_PROJECT_ID`, `DB_NAME`) are set before deploying, and that all module paths (`externals/…`) are correct.  