### PR TITLE
Add configurable ChromaDB storage and ignore storage dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# chromadb
+storage/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/data/memory.py
+++ b/data/memory.py
@@ -14,7 +14,9 @@ firestore_client = firestore.Client(project=os.getenv("DB_PROJECT_ID"), database
 client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
 
 # ChromaDB Configuration
-chroma_client = chromadb.PersistentClient("/storage/chroma")
+storage_path = os.getenv("CHROMA_STORAGE_PATH", "./storage/chroma")
+os.makedirs(storage_path, exist_ok=True)
+chroma_client = chromadb.PersistentClient(path=storage_path)
 collection = chroma_client.get_or_create_collection(name="memories")
 
 

--- a/main.py
+++ b/main.py
@@ -53,15 +53,10 @@ def _handle_general_chat(user_message: str) -> str:
     # Fetch context for the chat
     relevant_memories = fetch_similar_memories(user_message)
     memory_block = "\n".join(relevant_memories)
-    #TODO:
-    # 3. Update readme with new env vars
-    # 4. Create the new envvars in production
-    # 5. Implement chromaDB in production
-    # 6. Deploy and test
-    # Fetch latest messages for context
     response = chat(user_message, memory_block)
     # Save assistant response to the database
     save_message("assistant", response)
+    # TODO: save embedding of assistant response
     return response
 
 

--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,9 @@
 [![Python](https://img.shields.io/badge/python-3.9+-blue)]()
 [![License](https://img.shields.io/badge/license-MIT-green)]()
 
-Klaus is a cloud-native Telegram bot (and HTTP API) that helps you manage your Habitica **todo** and **daily** tasks via natural-language commands. Under the hood it uses:
+Klaus is a cloud-native bot that helps you manage your tasks via natural-language commands. Under the hood it uses:
 
-- **Habitica API** to fetch, create and complete tasks  
+- **Habitica API** to fetch, create and complete tasks 
 - **Google Gemini (Vertex AI)** for NLP: intent classification & task suggestions  
 - **RapidFuzz** for fuzzy matching approximate task titles  
 - **Firestore** & **ChromaDB** for conversational memory and embeddings  
@@ -58,7 +58,7 @@ In the future, it will be much more.
   - Firestore enabled  
   - A (writable) GCS bucket or persistent volume for ChromaDB  
 - Habitica account + API token  
-- Telegram bot token & secret  
+- Telegram bot token & secret (or any other simple frontend)
 
 ---
 
@@ -69,11 +69,12 @@ In the future, it will be much more.
 | `HABITICA_USER_ID`            | Your Habitica user ID                              |
 | `HABITICA_API_TOKEN`          | Your Habitica API token                            |
 | `GEMINI_API_KEY`              | Your Vertex AI (Gemini) API key                    |
-| `TELEGRAM_BOT_TOKEN`          | Telegram Bot token                                  |
-| `TELEGRAM_SECRET_TOKEN`       | Telegram webhook secret                             |
-| `TELEGRAM_ALLOWED_CHAT_IDS`   | Comma-separated list of allowed Telegram chat IDs   |
-| `DB_PROJECT_ID`               | GCP project ID for Firestore                        |
-| `DB_NAME`                     | Firestore database name                             |
+| `TELEGRAM_BOT_TOKEN`          | Telegram Bot token                                 |
+| `TELEGRAM_SECRET_TOKEN`       | Telegram webhook secret                            |
+| `TELEGRAM_ALLOWED_CHAT_IDS`   | Comma-separated list of allowed Telegram chat IDs  |
+| `DB_PROJECT_ID`               | GCP project ID for Firestore                       |
+| `DB_NAME`                     | Firestore database name                            |
+| `CHROMA_STORAGE_PATH`         | Path of mounted volume                             |
 
 ---
 


### PR DESCRIPTION
This PR makes the following updates:

1. **`.gitignore`**  
   - Ignore the `storage/` directory (ChromaDB data) by adding:
     ```gitignore
     # chromadb
     storage/
     ```
2. **`data/memory.py`**  
   - Introduce `CHROMA_STORAGE_PATH` env var (default `./storage/chroma`) for ChromaDB persistence.  
   - Ensure the storage directory exists at startup (`os.makedirs(...)`).  
   - Update `PersistentClient` to use the configurable path.
3. **`README.md`**  
   - Simplify the project description to generic “bot” instead of Telegram-only.  
   - Clarify that any simple frontend can be used, not just Telegram.  
   - Add the new `CHROMA_STORAGE_PATH` environment variable to the configuration table.

These changes improve configurability of the ChromaDB backend and keep local storage out of version control.  